### PR TITLE
Added reagent/create-class

### DIFF
--- a/src/scittle/reagent.cljs
+++ b/src/scittle/reagent.cljs
@@ -8,7 +8,8 @@
 
 (def reagent-namespace
   {'atom (sci/copy-var r/atom rns)
-   'as-element (sci/copy-var r/as-element rns)})
+   'as-element (sci/copy-var r/as-element rns)
+   'create-class (sci/copy-var r/create-class rns)})
 
 (def rdns (sci/create-ns 'reagent.dom nil))
 


### PR DESCRIPTION
I'm trying to use `scittle` standalone in my blog importing it from the CDN.
I'm thinking other than `create-class` if makes sense importing the entire `reagent` namespace.