### PR TITLE
Export register-plugin! to access the sci context

### DIFF
--- a/src/scittle/core.cljs
+++ b/src/scittle/core.cljs
@@ -43,7 +43,7 @@
                     (or (ex-cause e) e)
                     e))))))
 
-(defn register-plugin! [plug-in-name sci-opts]
+(defn ^:export register-plugin! [plug-in-name sci-opts]
   plug-in-name ;; unused for now
   (swap! ctx sci/merge-opts sci-opts))
 


### PR DESCRIPTION
Using `scittle` standalone without cljs I need a way to access the context and bind functions/vars to the namespace.