### PR TITLE
Fix bookmarklet share link

### DIFF
--- a/resources/public/cljs/bookmarklet.cljs
+++ b/resources/public/cljs/bookmarklet.cljs
@@ -134,6 +134,7 @@
      [:br]
      [(fn []
         [:a {:href (str "?name=" (js/encodeURIComponent @*bookmark-name)
-                        "&code=" (js/encodeURIComponent @*code))} "Copy this link to share ⤴️"])]]))
+                        "&code=" (js/encodeURIComponent @*code)
+                        " ")} "Copy this link to share ⤴️"])]]))
 
 (rdom/render [workspace] (.getElementById js/document "app"))


### PR DESCRIPTION
For some reason, Twitter (and possibly other sites!) cut closing parens from the "Copy this link to share ⤴️" link. So a quick-and-dirty fix is to just append a bit of whitespace.

A little more context (with pictures): https://twitter.com/CarnunMP/status/1559148858118111234

___

Please answer the following questions and leave the below in as part of your PR.

- [ ] I have read the [developer documentation](https://github.com/babashka/scittle/blob/main/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/scittle/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

<!-- - [ ] This PR contains a [test](https://github.com/babashka/scittle/blob/main/doc/dev.md#tests) to prevent against future regressions -->

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/scittle/blob/main/CHANGELOG.md) file with a description of the addressed issue.
