### PR TITLE
Fix scittle.nrepl to honor SCITTLE_NREPL_WEBSOCKET_PORT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix for [44](https://github.com/babashka/scittle/issues/44): Honoring `SCITTLE_NREPL_WEBSOCKET_PORT` in `scittle.nrepl`
+
 ## v0.3.10
 
 - Add `scittle.promesa.js` plugin. This gives access to the [promesa](https://cljdoc.org/d/funcool/promesa/8.0.450/doc/user-guide) library.

--- a/doc/nrepl/bb.edn
+++ b/doc/nrepl/bb.edn
@@ -5,7 +5,8 @@
  :tasks {http-server {:doc "Starts http server for serving static files"
                       :requires ([babashka.http-server :as http])
                       :task (do (http/serve {:port 1341 :dir "."})
-                                (println "Serving static assets at http://localhost:1341"))}
+                                (println "Serving static assets at http://localhost:1341")
+                                (deref (promise)))}
 
          browser-nrepl {:doc "Start browser nREPL"
                         :requires ([sci.nrepl.browser-server :as bp])

--- a/doc/nrepl/bb.edn
+++ b/doc/nrepl/bb.edn
@@ -5,8 +5,7 @@
  :tasks {http-server {:doc "Starts http server for serving static files"
                       :requires ([babashka.http-server :as http])
                       :task (do (http/serve {:port 1341 :dir "."})
-                                (println "Serving static assets at http://localhost:1341")
-                                (deref (promise)))}
+                                (println "Serving static assets at http://localhost:1341"))}
 
          browser-nrepl {:doc "Start browser nREPL"
                         :requires ([sci.nrepl.browser-server :as bp])

--- a/src/scittle/nrepl.cljs
+++ b/src/scittle/nrepl.cljs
@@ -34,7 +34,7 @@
 (defn ws-url [host port path]
   (str "ws://" host ":" port "/" path))
 
-(let [ws-port (or (.-SCITTLE_NREPL_WEBSOCKET_PORT js/window) 1340)]
+(when-let [ws-port (.-SCITTLE_NREPL_WEBSOCKET_PORT js/window)]
   (set! (.-ws_nrepl js/window)
         (new js/WebSocket (ws-url "localhost" ws-port "_nrepl"))))
 

--- a/src/scittle/nrepl.cljs
+++ b/src/scittle/nrepl.cljs
@@ -31,9 +31,12 @@
     :complete (let [completions (completions (assoc msg :ctx @!sci-ctx))]
                 (nrepl-reply msg completions))))
 
-(when (.-SCITTLE_NREPL_WEBSOCKET_PORT js/window)
+(defn ws-url [host port path]
+  (str "ws://" host ":" port "/" path))
+
+(let [ws-port (or (.-SCITTLE_NREPL_WEBSOCKET_PORT js/window) 1340)]
   (set! (.-ws_nrepl js/window)
-        (new js/WebSocket "ws://localhost:1340/_nrepl")))
+        (new js/WebSocket (ws-url "localhost" ws-port "_nrepl"))))
 
 (when-let [ws (nrepl-websocket)]
   (prn :ws ws)


### PR DESCRIPTION
Fix `scittle.nrepl` to honor `SCITTLE_NPREL_WEBSOCKET_PORT` with a default of 1340.


Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/scittle/blob/main/doc/dev.md).

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/scittle/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

<!-- - [ ] This PR contains a [test](https://github.com/babashka/scittle/blob/main/doc/dev.md#tests) to prevent against future regressions -->

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/scittle/blob/main/CHANGELOG.md) file with a description of the addressed issue.
