### PR TITLE
Upgrade sci configs (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Unreleased
 
 - Use `window.location.hostname` for WebSocket connection
-- Upgrade sci configs to `bf8d209e`
+- Upgrade sci configs to `20f08f18`
 - Update nrepl implementation, implement `eldoc` (`info`, `lookuup`)
 
 ## v0.5.14 (2023-01-05)

--- a/bb.edn
+++ b/bb.edn
@@ -1,6 +1,6 @@
 {:deps {io.github.babashka/sci.nrepl
         #_{:local/root "../sci.nrepl"}
-        {:git/sha "c14b5b4ef4390ff206cdb71f763f327799f5e853"}
+        {:git/sha "2f8a9ed2d39a1b09d2b4d34d95494b56468f4a23"}
         io.github.babashka/http-server
         {:git/sha "b38c1f16ad2c618adae2c3b102a5520c261a7dd3"}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
  :deps
  {org.clojure/clojure {:mvn/version "1.11.1"}
   org.babashka/sci {:git/url "https://github.com/babashka/sci"
-                    :git/sha "6d20f08f189ff4027b682f33f93efd20d9e2d2d7"}
+                    :git/sha "20f08f189ff4027b682f33f93efd20d9e2d2d7"}
   #_{:local/root "../babashka/sci"}
   reagent/reagent {:mvn/version "1.1.1"}
   re-frame/re-frame {:mvn/version "1.3.0"}
@@ -15,7 +15,7 @@
   io.github.babashka/sci.nrepl
   #_{:local/root "../sci.nrepl"}
   {:git/url "https://github.com/babashka/sci.nrepl"
-   :git/sha "b75700da7797f9fc2b4ef1bef9df7230f9fd1e8c"}
+   :git/sha "2f8a9ed2d39a1b09d2b4d34d95494b56468f4a23"}
   io.github.babashka/sci.configs
   #_{:local/root "/Users/borkdude/dev/sci.configs"}
   {:git/url "https://github.com/babashka/sci.configs"


### PR DESCRIPTION
See #50. 
Sorry for the second pull request. For the eldoc update, you need a `scittle.nrepl` build with the updated `sci.nrepl`. 

Also if somebody mixes their `sci.nrepl` version with an old `scittle.nrepl` version. It will likely not be functional. E.g. cider would ask for `describe` but the nrepl would not handle it.
(This happens if somebody would right now use the latest `sci.nrepl` + the non-updated `scittle.nrepl`. 
Hope that makes sense and doesn't break anybody. 
