### PR TITLE
Use latest sci.nrepl in the example

### DIFF
--- a/doc/nrepl/bb.edn
+++ b/doc/nrepl/bb.edn
@@ -1,5 +1,5 @@
 {:deps {io.github.babashka/sci.nrepl
-        {:git/sha "c14b5b4ef4390ff206cdb71f763f327799f5e853"}
+        {:git/sha "2f8a9ed2d39a1b09d2b4d34d95494b56468f4a23"}
         io.github.babashka/http-server
         {:git/sha "b38c1f16ad2c618adae2c3b102a5520c261a7dd3"}}
  :tasks {http-server {:doc "Starts http server for serving static files"


### PR DESCRIPTION
https://clojurians.slack.com/archives/C6QH853H8/p1677323931039009     
I accidentally changed the sci deps. Not sure why it happenend. 

Double checked sci.nrepl deps and there is another usage in the example doc so I updated this to latest sci.nrepl. 
(Double checking this time that it is a correct commit). 