### PR TITLE
Fix #89: Allow evaluate_script_tags to specify scripts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 <!-- - Create Github release with updated links from `doc/links.md` -->
 <!-- - `bb gh-pages` -->
 
+- [#89](https://github.com/babashka/babashka/issues/89): allow `evaluate_script_tags` to specify individual scripts.
+
 ## v0.6.19 (2024-10-08)
 
 - Add `cljs.pprint/code-dispatch` and `cljs.pprint/with-pprint-dispatch`

--- a/src/scittle/core.cljs
+++ b/src/scittle/core.cljs
@@ -103,8 +103,10 @@
           (eval-script-tags* (rest script-tags)))
         (eval-script-tags* (rest script-tags))))))
 
-(defn ^:export eval-script-tags []
-  (let [script-tags (.querySelectorAll doc "script[type='application/x-scittle']")]
+(defn ^:export eval-script-tags [& script-tags]
+  (let [script-tags (or script-tags
+                        (.querySelectorAll
+                          doc "script[type='application/x-scittle']"))]
     (eval-script-tags* script-tags)))
 
 (def auto-load-disabled? (volatile! false))


### PR DESCRIPTION
Fixes #87 and allows reloading of individual cljs script tags as well as the existing behaviour of reloading all script tags.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/scittle/blob/main/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/scittle/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/scittle/blob/main/CHANGELOG.md) file with a description of the addressed issue.
