### PR TITLE
Ability to evaluate single, query, or col of script tags.

### DIFF
--- a/src/scittle/core.cljs
+++ b/src/scittle/core.cljs
@@ -103,10 +103,14 @@
           (eval-script-tags* (rest script-tags)))
         (eval-script-tags* (rest script-tags))))))
 
-(defn ^:export eval-script-tags [& script-tags]
+(defn ^:export eval-script-tags [& [script-tags]]
   (let [script-tags (or script-tags
                         (.querySelectorAll
-                          doc "script[type='application/x-scittle']"))]
+                          doc "script[type='application/x-scittle']"))
+        script-tags (if (or (coll? script-tags)
+                            (aget script-tags "length"))
+                      script-tags
+                      [script-tags])]
     (eval-script-tags* script-tags)))
 
 (def auto-load-disabled? (volatile! false))


### PR DESCRIPTION
Additional PR for #89 to address discussion here: https://github.com/babashka/scittle/discussions/92

This adds the ability to pass either:
* a single script tag
* a `col` of script tags
* a `querySelectorAll()` of tags (`NodeList` or other JS array-like)
into `scittle.core.eval_script_tags()` and have it do the right thing.

Tested like this (with hello.cljs and thing.cljs test scripts in the current dir):
```clojure
(let [scripts (.querySelectorAll
                js/document
                "script[src='hello.cljs'],script[src='thing.cljs']")
      script (first scripts)]
  (js/console.log "scripts" scripts)
  ; load single tag
  (js/console.log "loading" (-> scripts first (aget "src")))
  (-> js/scittle
      .-core
      (.eval_script_tags script))
  ; load all the tags
  (js/console.log "loading all tags" scripts)
  (-> js/scittle
      .-core
      (.eval_script_tags scripts))
  ; load a js array of the scripts
  (js/console.log "loading all tags as js array")
  (-> js/scittle
      .-core
      (.eval_script_tags (js/Array.from scripts)))
  ; load a native clj seq of the scripts
  (js/console.log "loading all tags as vec")
  (-> js/scittle
      .-core
      (.eval_script_tags [(first scripts) (second scripts)])))
```


Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/scittle/blob/main/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/scittle/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

<!-- - [ ] This PR contains a [test](https://github.com/babashka/scittle/blob/main/doc/dev.md#tests) to prevent against future regressions -->

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/scittle/blob/main/CHANGELOG.md) file with a description of the addressed issue.

(Update to #89 and discussion so doesn't need a new CHANGELOG.md line I think).