### PR TITLE
Add goog.string/htmlEscape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 <!-- - `bb gh-pages` -->
 
 - [#102](https://github.com/babashka/scittle/issues/102): add `applied-science/js-interop` plugin.
+- [#105](https://github.com/babashka/scittle/issues/105): add `goog.string/htmlEscape`.
 
 ## v0.6.22 (2024-12-19)
 

--- a/src/scittle/core.cljs
+++ b/src/scittle/core.cljs
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [time])
   (:require [cljs.reader :refer [read-string]]
             [goog.object :as gobject]
-            [goog.string]
+            [goog.string :as gstring]
             [sci.core :as sci]
             [sci.ctx-store :as store]
             [sci.impl.unrestrict]
@@ -46,6 +46,7 @@
     'abs (sci/copy-var abs cljns)}
    'goog.object {'set gobject/set
                  'get gobject/get}
+   'goog.string {'htmlEscape gstring/htmlEscape}
    'sci.core {'stacktrace sci/stacktrace
               'format-stacktrace sci/format-stacktrace}})
 


### PR DESCRIPTION
Hi,

could please consider patch to add the `goog.string/htmlEscape` fn. It addresses #105.

There doesn’t appear to be a test suite available, so I tested this manually by inserting the following into `resources/public/index.html` and observing the console output:

```clojurescript
      (require '[goog.string :as gstring])
      (println :escape (gstring/htmlEscape "<hello>">))
=> :escape &lt;hello&gt;
```
Thanks

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/scittle/blob/main/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/scittle/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

<!-- - [ ] This PR contains a [test](https://github.com/babashka/scittle/blob/main/doc/dev.md#tests) to prevent against future regressions -->

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/scittle/blob/main/CHANGELOG.md) file with a description of the addressed issue.
