### PR TITLE
Map string requires to globalThis JS deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ babashka or Clojure JVM):
 
 See [doc/nrepl](doc/nrepl).
 
+### Service worker
+
+See [doc/serviceworker.md](doc/serviceworker.md).
+
 ## Tasks
 
 Run `bb tasks` to see all available tasks:

--- a/doc/serviceworker.md
+++ b/doc/serviceworker.md
@@ -1,0 +1,26 @@
+# Scittle in a service worker
+
+You can use Scittle to bootstrap a ClojureScript based service worker.
+
+Put the following code into e.g. `scittle-sw.js` to create a JavaScript based service worker, load Scittle, then fetch your script and eval it.
+
+```javascript
+importScripts("scittle.min.js");
+
+const request = await fetch("sw.cljs");
+const text = await request.text();
+const result = scittle.core.eval_string(text);
+```
+
+Then load `scittle-sw.js` in your HTML:
+
+```html
+<script>
+  if('serviceWorker' in navigator)
+    navigator.serviceWorker.register('scittle-sw.js');
+</script>
+```
+
+This will load `sw.cljs` and eval it in the context of the service worker.
+
+A ready-made example can be found at [chr15m/scittle-template-serviceworker](https://github.com/chr15m/scittle-template-serviceworker).

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -147,6 +147,19 @@
     addition to <tt>scittle.js</tt>, you need to
     include <tt>scittle.pprint.js</tt>.
 
+    <a name="reader-conditional"></a>
+    <h2><a href="#reader-conditional">Target :scittle in cljc</a></h2>
+    You can target scittle in .cljc files (use a script tag to include the cljc file) with the <code>:scittle</code> reader conditional like this:<br>
+
+    <pre><code class="clojure">
+    #?(:scittle
+       (js/console.log "In scittle")
+       :org.babashka/nbb
+       (js/console.log "In nbb")
+       :cljs
+       (js/console.log "In cljs"))
+    </code></pre>
+
     <a name="repl"></a>
     <h2><a href="#nrepl">REPL</a></h2>
 

--- a/src/scittle/core.cljs
+++ b/src/scittle/core.cljs
@@ -49,13 +49,19 @@
    'sci.core {'stacktrace sci/stacktrace
               'format-stacktrace sci/format-stacktrace}})
 
+(defn load-fn [{:keys [ctx] :as opts}]
+  (when-let [lib (and (string? (:namespace opts))
+                      (gobject/get js/globalThis (:namespace opts)))]
+    (sci/add-js-lib! ctx (:namespace opts) lib)))
+
 (store/reset-ctx!
   (sci/init {:namespaces namespaces
              :classes {'js js/globalThis
                        :allow :all
                        'Math js/Math}
              :ns-aliases {'clojure.pprint 'cljs.pprint}
-             :features #{:scittle :cljs}}))
+             :features #{:scittle :cljs}
+             :load-fn load-fn}))
 
 (unchecked-set js/globalThis "import" (js/eval "(x) => import(x)"))
 


### PR DESCRIPTION
Fixes #95. This patch updates Scittle to support requiring already-loaded script tag JS deps off `globalThis`. Workflow:

```html
<script src="https://cdn.jsdelivr.net/npm/js-confetti@latest/dist/js-confetti.browser.js"></script>
```

```clojure
(ns main
  (:require
    ["JSConfetti" :as c]))

(.addConfetti (c.))
```

You can also use esm imports in your index.html if you monkey-patch them onto `globalThis/window` before Scittle runs.

I'm not sure my naïve implementation is future proof so don't hesitate to reject or ask for changes. On #95 we spoked about [David's plan](https://clojure.atlassian.net/browse/CLJS-3233) to give globalThis requires a special syntax, and this patch should be forwards compatible with any future syntax I think.

In future it could also be adapted to load es modules using maybe `sci.async`. So it would try two loaders for a string require: 1. from globalThis 2. looking up the import map and doing an async esm import from the url specified. That's outside the scope of this PR though.

---

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/scittle/blob/main/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/scittle/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/scittle/blob/main/CHANGELOG.md) file with a description of the addressed issue.
