### PR TITLE
 Support string requires of `globalThis` js deps #95

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 <!-- - Create Github release with updated links from `doc/links.md` -->
 <!-- - `bb gh-pages` -->
 
+- [#95](https://github.com/babashka/scittle/issues/121): support string requires of `globalThis` js deps ([@chr15m](https://github.com/chr15m))
+
 ## v0.7.26 (2025-08-20)
 
 - [#121](https://github.com/babashka/scittle/issues/121): add `cjohansen/dataspex` plugin ([@jeroenvandijk](https://github.com/jeroenvandijk))

--- a/src/scittle/core.cljs
+++ b/src/scittle/core.cljs
@@ -53,13 +53,19 @@
    'sci.core {'stacktrace sci/stacktrace
               'format-stacktrace sci/format-stacktrace}})
 
+(defn load-fn [{:keys [ctx] :as opts}]
+  (when-let [lib (and (string? (:namespace opts))
+                      (gobject/get js/globalThis (:namespace opts)))]
+    (sci/add-js-lib! ctx (:namespace opts) lib)))
+
 (store/reset-ctx!
   (sci/init {:namespaces namespaces
              :classes {'js js/globalThis
                        :allow :all
                        'Math js/Math}
              :ns-aliases {'clojure.pprint 'cljs.pprint}
-             :features #{:scittle :cljs}}))
+             :features #{:scittle :cljs}
+             :load-fn load-fn}))
 
 (unchecked-set js/globalThis "import" (js/eval "(x) => import(x)"))
 


### PR DESCRIPTION
Fixes #95. This patch updates Scittle to support requiring already-loaded script tag JS deps off `globalThis`. Workflow:

```html
<script src="https://cdn.jsdelivr.net/npm/js-confetti@latest/dist/js-confetti.browser.js"></script>
```

```clojure
(ns main
  (:require
    ["JSConfetti" :as c]))

(.addConfetti (c.))
```

You can also use esm imports in your index.html if you monkey-patch them onto `globalThis/window` before Scittle runs.

I'm not sure my naïve implementation is future proof so don't hesitate to reject or ask for changes. On #95 we spoked about [David's plan](https://clojure.atlassian.net/browse/CLJS-3233) to give globalThis requires a special syntax, and this patch should be forwards compatible with any future syntax I think.

In future it could also be adapted to load es modules using maybe `sci.async`. So it would try two loaders for a string require: 1. from globalThis 2. looking up the import map and doing an async esm import from the url specified. That's outside the scope of this PR though.

---

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/babashka/scittle/blob/main/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/scittle/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/scittle/blob/main/CHANGELOG.md) file with a description of the addressed issue.
