### PR TITLE
Enable source maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 <!-- - Create Github release with updated links from `doc/links.md` -->
 <!-- - `bb gh-pages` -->
 
+- [#114](https://github.com/babashka/scittle/issues/114): Enable source maps ([@jeroenvandijk](https://github.com/jeroenvandijk))
+
 ## v0.7.28 (2025-09-13)
 
 - [#137](https://github.com/babashka/scittle/issues/137): fix JS interop with reserved JS keyword (incorrectly munged) by bumping SCI

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -6,10 +6,13 @@
 
  :builds
  {:main
-  {;; for dev build
-   #_#_:compiler-options {:optimizations :simple
-                          :pretty-print true
-                          :pseudo-names true}
+  {;:compiler-options {:source-map true}
+   ;; for dev build   
+   #_#_
+   :compiler-options {:optimizations :simple
+                      :pretty-print true
+                      :pseudo-names true
+                      :source-map true}
    :target     :browser
    :js-options
    {:resolve {"react" {:target :global
@@ -37,4 +40,5 @@
                         :depends-on #{:scittle}}}
    :build-hooks [(shadow.cljs.build-report/hook)]
    :output-dir "resources/public/js" ;; + "/dev" for dev build
-   :devtools   {:repl-pprint true}}}}
+   :devtools   {:repl-pprint true}
+   }}}


### PR DESCRIPTION
Fixes #114 

This PR enables source map. The only difference in the resulting build is that the `.js` have an `//# sourceMappingURL=...` line at the end. If the `.map` files are also uploaded this should allow source maps to work.


Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [developer documentation](https://github.com/babashka/scittle/blob/main/doc/dev.md).

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/scittle/blob/main/doc/dev.md#start-with-an-issue-before-writing-code).

<!-- - [ ] This PR contains a [test](https://github.com/babashka/scittle/blob/main/doc/dev.md#tests) to prevent against future regressions -->

- [X] I have updated the [CHANGELOG.md](https://github.com/babashka/scittle/blob/main/CHANGELOG.md) file with a description of the addressed issue.
